### PR TITLE
Run the test suite in CI, not just build+lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   pull_request:
@@ -26,3 +26,5 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run lint
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary
CI built and linted every PR across 3 Node versions, but never ran the real test suite — this repo had no tests at all until earlier this session (20 tests, 100% stmt/line/func coverage). Adds a \`Test\` step running \`npm test\`.

Confirmed locally that vitest correctly runs once-and-exits under \`CI=true\` (its local default without that is watch mode, which would hang a runner) — GitHub Actions sets \`CI=true\` automatically, so no other change was needed.

## Test plan
- [x] \`CI=true npm test\` — 20/20 pass